### PR TITLE
:sparkles: Exhibition Search 페이지 - UI 구현

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -12,6 +12,7 @@ import Home from "./pages/Home";
 import StroyDetail from "./pages/StoryDetail";
 import StoryWrite from "./pages/StoryWrite";
 import ExhibitionDetail from "./pages/ExhibitionDetail";
+import ExhibitionSearch from "./pages/ExhibitionSearch";
 
 
 function App() {
@@ -25,6 +26,7 @@ function App() {
         <Route  path="/onborading" element={<Onboarding />}/>
         <Route  path="/exhibition" element={<Exhibition />}/>
         <Route path="/exhibition/:id" element={<ExhibitionDetail />}/>
+        <Route path="/exhibition/search" element={<ExhibitionSearch />}/>
         <Route path="/story" element={<Story/>}/>
         <Route path="/mystory" element={<MyStory/>}/>
         <Route path="/mystory/storywrite" element={<StoryWrite/>}/>

--- a/src/entites/Exibition/ui/ExhibitionMap.jsx
+++ b/src/entites/Exibition/ui/ExhibitionMap.jsx
@@ -90,7 +90,7 @@ const ExhibitionMap = ({ address, place }) => {
     <MapLayout>
       <MapContainer ref={mapContainer} />
       <AddressContainer>
-        <AddresText>위치 : </AddresText>
+        <AddresText>위치 :&nbsp;</AddresText>
         <Address>{address} {place}</Address>
       </AddressContainer>
     </MapLayout>
@@ -106,7 +106,7 @@ const MapLayout = styled.div`
 `;
 
 const MapContainer = styled.div`
-  width: 1012px;
+width:1014px;
   height: 406px;
 `;
 

--- a/src/entites/Story/Search.jsx
+++ b/src/entites/Story/Search.jsx
@@ -9,17 +9,22 @@ export default function Search({ searchItems, setSearchItems, placeholder, type 
     const [input, setInput] = useState('');
 
     useEffect(() => {
-        if (input === '') {
-            setSearchItems([]); // 빈 입력일 때 캐러셀 표시
-        }
+        /* 이거 주석 해제하면 Exhibition Search에서 문제 발생 */
+        // if (input === '') {
+        //     setSearchItems([]); // 빈 입력일 때 캐러셀 표시
+        // } 
     }, [input, setSearchItems])
 
     // 엔터 키를 눌렀을 때 검색 실행
     const handleKeyDown = (e) => {
         if (e.key === 'Enter') {
             if(input === '') {
-                setSearchItems([]); // 빈 입력일 때 캐러셀 표시
-            } else {
+                //setSearchItems([]); // 빈 입력일 때 캐러셀 표시
+                // 빈 입력일 경우 전체 데이터 표시
+                const allData = type === 'story' ? Stories : Exhibitions;
+                setSearchItems(allData);
+            } 
+            else {
                 let filteredData=[];
                 if(type === 'story'){
                     filteredData = Stories.filter(story => story.전시이름.includes(input));
@@ -57,11 +62,9 @@ const SearchContainer = styled.div`
 width: 419px;
 display:flex;
 gap: 10px;
-padding: 9px;
+padding: 10px;
 box-shadow: 1px 2px 8px #f3f3f3;
 border: none;
-
-
 `;
 
 const SearchImg = styled.img`

--- a/src/pages/Exhibition.jsx
+++ b/src/pages/Exhibition.jsx
@@ -1,69 +1,62 @@
-import React, { useState } from 'react'
-import styled from 'styled-components'
+import React, { useState, useEffect } from 'react';
+import styled from 'styled-components';
 import Banner from '../entites/Exibition/ui/Banner';
+import { useNavigate, useLocation } from 'react-router-dom';
 import Carousel from '../entites/Story/Carousel';
 import Search from '../entites/Story/Search';
-import StandardPoster from '../shared/components/StandardPoster';
 
 export default function Exhibition() {
-  const [searchExhibition, setSearchExhibitions] = useState([]); // 검색하고자 하는 전시를 저장하는 배열
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const [searchExhibition, setSearchExhibitions] = useState([]); // 검색 결과 저장
+
+  // 페이지 렌더링 시 검색 상태를 초기화
+  useEffect(() => {
+    if (location.state?.fromSearch) {
+      setSearchExhibitions([]); // 검색 상태 초기화
+    }
+  }, [location]);
+
+  const handleSearch = (searchResults) => {
+      setSearchExhibitions(searchResults); // 검색 결과 저장
+      navigate('/exhibition/search', { state: { searchResults } }); // 검색 결과를 가지고 페이지 이동
+  };
+
   return (
     <ExhibitionLayout>
       {/* 스와이퍼 배너 영역 */}
-      <BannerWrapper> 
-        {/* 배너 컴포넌트 */}
-        <Banner/>
+      <BannerWrapper>
+        <Banner />
       </BannerWrapper>
 
       {/* 검색바 컴포넌트 */}
-      <Search searchItems={searchExhibition} setSearchItems={setSearchExhibitions} placeholder="원하는 전시를 검색해보세요" type="exhibition"/> {/* Story 페이지와는 다르게 placeholer 추가 */}
-      {searchExhibition.length > 0 ? (
-        <>
-        <SearchResultLayout>
-          {searchExhibition.map((data) => (
-            <SearchPosterBox key={data.아이디}>
-              <StandardPoster id={data.아이디} poster={data.포스터} />
-            </SearchPosterBox>
-          ))}
-          </SearchResultLayout>
-        </>
-      ) : (
-        <>
-        {/* 캐러셀 */}
-          <Carousel title={'인기 전시'} type={'exhibition'} />
-          <Carousel title={'최근 전시'} type={'exhibition'} />
-          <Carousel title={'추천 전시'} type={'exhibition'} />     
-          <Carousel title={'최근 추천 전시'} type={'exhibition'} />
-          <Carousel title={'임박한 전시'} type={'exhibition'} />
-        </>
-      )
-      }
+      <Search
+        searchItems={searchExhibition}
+        setSearchItems={handleSearch}
+        placeholder="원하는 전시를 검색해보세요"
+        type="exhibition"
+      />
 
+      {/* 캐러셀 */}
+      <Carousel title={'인기 전시'} type={'exhibition'} />
+      <Carousel title={'최근 전시'} type={'exhibition'} />
+      <Carousel title={'추천 전시'} type={'exhibition'} />
+      <Carousel title={'최근 추천 전시'} type={'exhibition'} />
+      <Carousel title={'임박한 전시'} type={'exhibition'} />
     </ExhibitionLayout>
-  )
+  );
 }
 
-const ExhibitionLayout=styled.div`
-display : flex;
-flex-direction:column;
-align-items : center;
+const ExhibitionLayout = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 `;
 
-const BannerWrapper=styled.div`
-width:100%;
-height: 693px;
-background: var(--1, #0E0E0F);
-margin-bottom:104px;
-
-`;
-
-const SearchPosterBox = styled.div`
-display:flex;
-
-`;
-const SearchResultLayout = styled.div`
-display: flex;
-flex-wrap: wrap;
-justify-content: center;
-gap: 20px;
+const BannerWrapper = styled.div`
+  width: 100%;
+  height: 693px;
+  background: var(--1, #0E0E0F);
+  margin-bottom: 104px;
 `;

--- a/src/pages/ExhibitionDetail.jsx
+++ b/src/pages/ExhibitionDetail.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams} from 'react-router-dom';
 import styled from 'styled-components';
 import { Exhibitions } from '../shared/dummy/ExhibitionDummy';
 import ExhibitionInfo from '../entites/Exibition/ui/ExhibitionInfo';
@@ -34,12 +34,13 @@ const ExhibitionDetailLayout = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
+  padding : 135px 214px ;
 `;
 
 const ExhibitionTopContainer = styled.div`
   display: flex;
   gap: 154px;
-  margin: 134px 212px 128px 270px; // 피그마 규격
+  margin-bottom: 128px;
 `;
 
 const ExhibitionPoster = styled.img`

--- a/src/pages/ExhibitionSearch.jsx
+++ b/src/pages/ExhibitionSearch.jsx
@@ -1,0 +1,71 @@
+import React, { useState, useEffect } from 'react';
+import styled from 'styled-components';
+import { useLocation } from 'react-router-dom';
+import Search from '../entites/Story/Search';
+import StandardPoster from '../shared/components/StandardPoster';
+
+export default function ExhibitionSearch() {
+  const location = useLocation();
+  const initialResults = location.state?.searchResults || []; // 처음 로드 시 전달된 검색 결과
+  const [searchExhibition, setSearchExhibitions] = useState(initialResults); // 검색 결과 저장
+
+  // 검색 결과가 없을 때 텍스트 표시
+  const displayedExhibitions = searchExhibition.length > 0 ? searchExhibition : [];
+
+  return (
+    <ExhibitionSearchLayout>
+      <ExhibitionSearchWrpper>
+        {/* 검색바 컴포넌트 */}
+        <Search
+        searchItems={searchExhibition}
+        setSearchItems={setSearchExhibitions}
+        placeholder="원하는 전시를 검색해보세요"
+        type="exhibition"
+        />
+
+        {/* 검색 결과 부분 */}
+        <SearchResultContainer>
+          {displayedExhibitions.length > 0 ? (
+            displayedExhibitions.map((exhibition) => (
+              <PosterItem key={exhibition.아이디}>
+                <StandardPoster id={exhibition.아이디} poster={exhibition.포스터} />
+              </PosterItem>
+            ))
+          ) : (
+            <NoResultsText>검색 결과가 없습니다.</NoResultsText>
+          )}
+        </SearchResultContainer>
+      </ExhibitionSearchWrpper>
+    </ExhibitionSearchLayout>
+  );
+}
+
+const ExhibitionSearchLayout = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items:center;
+  padding: 50px 0px;
+`;
+
+const ExhibitionSearchWrpper=styled.div`
+  width:894px; // 계산된 크기
+`;
+
+const SearchResultContainer = styled.div`
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  margin-top: 50px;
+  jusify-content: space-between;
+  gap:50px;
+`;
+
+const PosterItem = styled.div`
+`;
+
+const NoResultsText = styled.div`
+  padding:0px 40px;
+  font-size: 13px;
+  color: #888;
+  text-align: center;
+`;

--- a/src/shared/components/Header.jsx
+++ b/src/shared/components/Header.jsx
@@ -27,7 +27,7 @@ export default function NavigationBar() {
       <PageSection>
         <StyledLink
           to="/exhibition"
-          selected={location.pathname === '/exhibition'}
+          selected={location.pathname === '/exhibition' || location.pathname==='/exhibition/' || location.pathname==='/exhibition/search'}
         >
           <div>EXHIBITION</div>
         </StyledLink>


### PR DESCRIPTION
### ✅ 이슈
- close #44 

<br>

### ✏️ 작업 내용
- Exhibition Search 페이지 구현
- 빈 검색어를 검색하면 전체 Exhibition이 나오도록 구현
- 검색어가 없을 경우, 검색 결과가 없다는 텍스트 표시

<br>

### 📷 개발 인증샷 (Postman 등)
<img width="1470" alt="image" src="https://github.com/user-attachments/assets/665c6a3d-7135-4962-8325-5552ef62095f">


<br>

### 💡 배운 것, 어려웠던 것 등 (없으면 생략 가능)
- 포스터 배치 때문에 옆에 여백이 살짝 남아서 ExhibitionSearchWrpper에 크기를 고정으로 계산해서 주었음
(894px -> 갭 50px * 3+ 포스터 186px * 3)
- 아직 포스터 누르면 이동하는 것까지는 구현하지 않았음
