### PR TITLE
:sparkles: Exhibition 페이지 - Swiper Banner 구현

### DIFF
--- a/src/entites/Exibition/ui/Banner.jsx
+++ b/src/entites/Exibition/ui/Banner.jsx
@@ -1,22 +1,89 @@
-import React from 'react'
-import NavigationBar from '../../../shared/components/Header'
-import styled from 'styled-components'
-import { Swiper, SwiperSlide } from 'swiper/react'
+import React, { useState, useEffect } from 'react';
+import styled from 'styled-components';
+import { Swiper, SwiperSlide } from 'swiper/react';
+import 'swiper/css';
+import 'swiper/css/effect-coverflow';
+import 'swiper/css/pagination';
+import { EffectCoverflow, Pagination } from 'swiper/modules';
+import { Exhibitions } from '../../../shared/dummy/ExhibitionDummy';
+import { useNavigate } from 'react-router-dom';
 
-export default function Banner() {
-    return (
-        <Slide>
-            <Card>
-                <CardImg></CardImg>
-            </Card>
-        </Slide>
-    )
-}
-
-const Slide=styled.div`
-
+const PosterImg = styled.img`
+  width: 339px;
+  height: 489px;
+  cursor: pointer; 
+  object-fit: cover; 
 `;
 
-const Card=styled.div``;
+const BannerLayout = styled.div`
+  text-align: center;
+  margin : 90px 0px 0px 0px;
+  overflow: hidden;
+  .swiper-pagination-bullet-active {
+    background: #ffffff;
+  }
+  .swiper-pagination {
+    position: relative;
+    top: 50px;
+  }
+  .swiper-pagination-bullet {
+    background: #ffffff;
+    width: 10px;
+    height: 10px;
+  }
+    .swiper-slide-shadow-left {
+    width : 300px;
+  }
+`;
 
-const CardImg=styled.div``;
+export default function Banner() {
+  const [randomExhibitionData, setRandomExhibitionData] = useState([]);
+  const navigate = useNavigate();
+
+  useEffect(() => { // Exhibitions를 랜덤하게 섞기
+    const shuffledData = [...Exhibitions].sort(() => 0.5 - Math.random()).slice(0, 12);
+    setRandomExhibitionData(shuffledData);
+  }, []);
+
+  const handlePosterClick = (id) => {
+    navigate(`/exhibition/${id}`); // 클릭 시 해당 페이지로 이동
+  };
+
+  return (
+    <BannerLayout>
+      <Swiper
+        effect={'coverflow'}
+        grabCursor={true}
+        centeredSlides={true}
+        slidesPerView={5}
+        spaceBetween={1}
+        initialSlide={6}
+        loop={true} // 무한 로드
+        loopedSlides={3} // 복사본 슬라이드
+        loopAdditionalSlides={5} // 추가 슬라이드 생성
+        lazy={true} // Lazy 로딩 활성화
+        preloadImages={true} // 이미지 미리 로드
+        coverflowEffect={{
+          rotate: 0,
+          stretch: 20,
+          depth: 100,
+          modifier: 1,
+          slideShadows: true,
+        }}
+        pagination={{
+          el: '.swiper-pagination',
+          clickable: true,
+        }}
+        modules={[EffectCoverflow, Pagination]}
+        className="mySwiper"
+      >
+        {randomExhibitionData.slice(0, 11).map((item, index) => (
+          <SwiperSlide key={index}>
+            <PosterImg src={item.포스터} alt={item.제목} onClick={() => handlePosterClick(item.아이디)}/>
+          </SwiperSlide>
+        ))}
+      </Swiper>
+      <div className="swiper-pagination"></div>
+    </BannerLayout>
+  );
+}

--- a/src/entites/Exibition/ui/ExhibitionInfo.jsx
+++ b/src/entites/Exibition/ui/ExhibitionInfo.jsx
@@ -94,7 +94,7 @@ font-family: Pretendard;
 font-size: 12px;
 font-style: normal;
 font-weight: 400;
-line-height: 133.072%; /* 15.969px */
+line-height: 133.072%;
 letter-spacing: 0.42px;
 `;
 

--- a/src/pages/Exhibition.jsx
+++ b/src/pages/Exhibition.jsx
@@ -57,6 +57,8 @@ const ExhibitionLayout = styled.div`
 const BannerWrapper = styled.div`
   width: 100%;
   height: 693px;
+  display:flex;
+  justify-content:center;
   background: var(--1, #0E0E0F);
   margin-bottom: 104px;
 `;


### PR DESCRIPTION
### ✅ 이슈
- close #46 

<br>

### ✏️ 작업 내용
- Banner 구현
- 이미지 클릭 시, 해당 Exhibition의 상세 페이지로 이동하도록

<br>

### 📷 개발 인증샷 (Postman 등)
<img width="1470" alt="image" src="https://github.com/user-attachments/assets/59c82bc0-e5c5-4b70-84b9-298b656a7882">

<br>

### 💡 배운 것, 어려웠던 것 등 (없으면 생략 가능)
- slidesPerView를 5로 설정했음에도 불구하고 화면에 계속 저렇게 7개가 뜨는 이유를 모르겠음
- 평가에 지대한 영향이 없다면,,, 이렇게 해도 되려나,,?
- 세밀한 디자인은 다같이 점검하고,, 수정할 수 있도록